### PR TITLE
Mutex/Threads fix

### DIFF
--- a/lib/libc/common/include/threads.h
+++ b/lib/libc/common/include/threads.h
@@ -19,15 +19,15 @@ extern "C" {
 typedef int (*thrd_start_t)(void *arg);
 
 enum {
-	thrd_success,
+	thrd_success = 4,
 #define thrd_success thrd_success
-	thrd_nomem,
+	thrd_nomem = 3,
 #define thrd_nomem thrd_nomem
-	thrd_timedout,
+	thrd_timedout = 5,
 #define thrd_timedout thrd_timedout
-	thrd_busy,
+	thrd_busy = 1,
 #define thrd_busy thrd_busy
-	thrd_error,
+	thrd_error = 2,
 #define thrd_error thrd_error
 };
 


### PR DESCRIPTION
Mutex lock would fail because the underlying pthreads function would return thrd_success which has different values in our separately-build C++ lib and Zephyr binary. This patch copies the explicit enum values from kotlin_mcu/include/threads.h into Zephyr's libc threads.h header.